### PR TITLE
Fix compatibility with newer Cython

### DIFF
--- a/AdaptivePELE/__init__.py
+++ b/AdaptivePELE/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 name = "AdaptivePELE"

--- a/AdaptivePELE/atomset/SymmetryContactMapEvaluator.pyx
+++ b/AdaptivePELE/atomset/SymmetryContactMapEvaluator.pyx
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import atomset
+#import atomset
 import numpy as np
 cimport cython
 cimport numpy as np

--- a/AdaptivePELE/atomset/atomset.pyx
+++ b/AdaptivePELE/atomset/atomset.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 from __future__ import unicode_literals
 import numpy as np
 import re

--- a/AdaptivePELE/freeEnergies/utils.pyx
+++ b/AdaptivePELE/freeEnergies/utils.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 import numpy as np
 from io import open
 cimport cython

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 [//] : # ## [1.x] - Unreleased
 
+## [1.7.4] - 2023-09-29
+
+### Bug fixes:
+
+    - Fix compatibility with latest Cython version
+
 ## [1.7.3] - 2023-01-31
 
 ### Bug fixes:


### PR DESCRIPTION
Recently Cython released a [new version](https://github.com/cython/cython/releases/tag/3.0.0) that breaks some of the functionality when compiling the package. (They jumped from 0.29 to 3.0)

This PR aims to fix this issue by setting the required compiling directives, as Cython 3.0 requires that Python 2 code is explicitly labeled on the beginning of the file with `cython: language_level=2`

Furthermore, one of the imports for `atomset` has been suppressed as it was giving issues on the compiled package. @AlbertCS maybe you could give a more deep explanation on why importing the module twice was needed?